### PR TITLE
Fix linewrapping bug

### DIFF
--- a/src/alfons/textBatch.cpp
+++ b/src/alfons/textBatch.cpp
@@ -214,7 +214,6 @@ glm::vec2 TextBatch::draw(const LineLayout& _line, glm::vec2 _position, float _w
 
             _position.y += _line.height();
             _position.x = startX;
-            lineWidth = 0;
         }
     }
 


### PR DESCRIPTION
Hi, 
I think there is a small mistake where `lineWidth` is first calculated correctly but then gets immediately reset to 0. (Be sure to check the expanded diff)

Here is side-by-side comparison of the issue with the `basic` demo

![grafik](https://cloud.githubusercontent.com/assets/4248696/21294335/a1cb5776-c53a-11e6-9eb6-5e10888a711f.png)
Left is before the change and right is after

Notice e.g. that the word `mots.` is cut of on the left image whereas on the right it is wrapped correctly. 

Edit: Upon further testing there seem to be some other edge cases with linewrapping, but this is a first step.