### PR TITLE
fix: faceId in LineLayout::Glyph got clamped to uint8

### DIFF
--- a/src/alfons/font.cpp
+++ b/src/alfons/font.cpp
@@ -18,16 +18,15 @@ Font::Font(const Properties& properties)
 
 auto Font::addFace(std::shared_ptr<FontFace> _face, hb_language_t _lang) -> bool {
 
+    if (!_face) { return false; }
+
     if (_lang == HB_LANGUAGE_INVALID) {
         m_faces.push_back(_face);
         return true;
     }
 
     for (auto& face : m_fontFaceMap[_lang]) {
-        if (face == _face) {
-            log("Won't add font twice. %s", _lang);
-            return false;
-        }
+        if (face == _face) { return false; }
     }
 
     m_fontFaceMap[_lang].push_back(_face);

--- a/src/alfons/fontManager.cpp
+++ b/src/alfons/fontManager.cpp
@@ -160,7 +160,6 @@ void FontManager::unload(Font& font) {
 }
 
 void FontManager::unload() {
-    // layoutCache.clear();
 
     for (auto& face : m_faces) {
         face->unload();
@@ -170,14 +169,11 @@ void FontManager::unload() {
 std::shared_ptr<FontFace> FontManager::addFontFace(const FontFace::Descriptor& descriptor,
                                                    float baseSize) {
 
-    // FontFace::Key key(descriptor, baseSize);
-    // for (const auto& face : faces) {
-    //     if (face.)
-    // }
-    // auto it = faces.find(key);
-    // if (it != faces.end()) {
-    //     return it->second.faceId;
-    // }
+    if (m_maxFontId == std::numeric_limits<uint16_t>::max()) {
+        LOGE("addFontFace failed: Reached maximum FontFace ID");
+        return nullptr;
+    }
+
     auto face = std::make_shared<FontFace>(m_ftHelper, m_maxFontId++, descriptor, baseSize);
 
     m_faces.push_back(face);

--- a/src/alfons/lineLayout.h
+++ b/src/alfons/lineLayout.h
@@ -34,7 +34,7 @@ enum class Alignment {
 
 struct Shape {
     // Reference to face within a Font.
-    uint8_t face;
+    uint16_t face;
     union {
         uint8_t flags;
         struct {
@@ -59,7 +59,7 @@ struct Shape {
 
     Shape() : face(0), flags(0), advance(0), codepoint(0) {}
 
-    Shape(uint8_t faceID, uint32_t codepoint, glm::vec2 offset,
+    Shape(uint16_t faceID, uint32_t codepoint, glm::vec2 offset,
           float advance, uint8_t flags)
         : face(faceID),
           flags(flags),


### PR DESCRIPTION
- handle up to 2^16 font faces