### PR TITLE
Fix macosx default system font

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,11 @@ if (NOT DEFINED ALFONS_DEPS_LIBRARIES)
   include(FindPkgConfig)
   pkg_check_modules(ICU REQUIRED icu-uc)
   pkg_check_modules(FREETYPE REQUIRED freetype2)
-  pkg_check_modules(HARFBUZZ REQUIRED harfbuzz)
+  if (APPLE)
+      pkg_check_modules(HARFBUZZ REQUIRED harfbuzz>=1.7.2)
+  else()
+      pkg_check_modules(HARFBUZZ REQUIRED harfbuzz)
+  endif()
 
   set(ALFONS_DEPS_LIBRARIES
     ${ICU_LDFLAGS}


### PR DESCRIPTION
- ".AppleSystemUIFont" does not return a valid CGFontRef when used as a font name!
  - We need to go through NSFont and get the apt CGFontRef
- Along with this, when creating hb_font using hb's coretext api on the above CGFontRef, it seems to be missing MORT and MORX font tables, which are necessary and required in hb's shape planner code. Because of this limitation, I ended up going the route of directly creating hb_font using ft_Face, which inturn is created from raw data read from the CGFontRef. Since we are not concerned about shaping with this "LATIN" font, we do not have to worry about creating a harfbuzz context with coretext for this font.

Refer: 
- https://github.com/mozilla/positron/blob/4b0595d06faa1617bd989a8c47231576f30ea6b2/gfx/thebes/gfxMacPlatformFontList.mm#L305-L326
- https://github.com/harfbuzz/harfbuzz/blob/7917792f01603f91b703d12e12d8baced655a615/src/hb-coretext.cc#L1258-L1276

Edit: Looks like harfbuzz coretext has been updated to include kerx table, which might also fix this the second issue of missing MORT and MORX tables. Refer: https://github.com/harfbuzz/harfbuzz/commit/84686bf4c75c001e7cfb2eabdf391b2e76cae335
